### PR TITLE
squeue needs a -t all argument to see completed jobs

### DIFF
--- a/gridctl.php
+++ b/gridctl.php
@@ -844,7 +844,7 @@ function get_local_status( $gfacID )
    $ruser     = "us3";
 
    if ( $is_squeu )
-      $cmd    = "squeue -j $gfacID 2>&1|tail -n 1";
+      $cmd    = "squeue -t all -j $gfacID 2>&1|tail -n 1";
    else
       $cmd    = "/usr/bin/qstat -a $gfacID 2>&1|tail -n 1";
 //write_log( "$self cmd: $cmd" );


### PR DESCRIPTION
I was checking the MinJobAge parameter in slurm (to keep completed jobs visible in squeue for MinJobAge seconds - default 300) and it wasn't working.
Turns out, completed jobs are not visible via squeue without the ```-t all``` parameter.

Testing (note this was a really quick job so we don't see it running):
```
[root@js237a slurm]# sbatch test.slurm	
Submitted batch job 22
[root@js237a slurm]# squeue
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
[root@js237a slurm]# squeue -j 22
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
[root@js237a slurm]# squeue -t all -j 22
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
                22     batch test_job     root CD       0:01      1 localhost
[root@js237a slurm]#
```

From: https://slurm.schedmd.com/slurm.conf.html
MinJobAge
    The minimum age of a completed job before its record is purged from Slurm's active database. Set the values of MaxJobCount and to ensure the slurmctld daemon does not exhaust its memory or other resources. The default value is 300 seconds. A value of zero prevents any job record purging. Jobs are not purged during a backfill cycle, so it can take longer than MinJobAge seconds to purge a job if using the backfill scheduling plugin. In order to eliminate some possible race conditions, the minimum non-zero value for MinJobAge recommended is 2. 