### PR TITLE
Enhance stats extraction with regex for model data

### DIFF
--- a/jobmonitor/cleanup_gfac.php
+++ b/jobmonitor/cleanup_gfac.php
@@ -402,11 +402,12 @@ write_logld( "$me: *messages.txt written" );
    $modelGUIDs = array();
    $mrecsIDs   = array();
    $rmodlGUIDs = array();
+   
 
    foreach ( $files as $file )
    {
       $split = explode( ";", $file );
-
+      $stats = array();
       if ( count( $split ) > 1 )
       {
          list( $fn, $meniscus, $mc_iteration, $variance ) = explode( ";", $file );
@@ -414,6 +415,15 @@ write_logld( "$me: *messages.txt written" );
          list( $other, $mc_iteration ) = explode( "=", $mc_iteration );
          list( $other, $variance     ) = explode( "=", $variance );
          list( $other, $meniscus     ) = explode( "=", $meniscus );
+         // REGEX EXTRACT HMETRIC DW KS EXCKURT if present and build a json to store in model table
+         $json_keys = array( 'HMETRIC', 'DW', 'KS', 'EXCKURT' );
+         foreach ( $json_keys as $key )
+         {
+             if ( preg_match( "/$key=([0-9]+.?[0-9eE\-+]*)/", $file, $matches ) )
+             {
+                 $stats[$key] = $matches[1];
+             }
+         }
       }
       else
          $fn = $file;
@@ -553,6 +563,25 @@ write_logld( "$me:   mrecs file editGUID=$editGUID" );
          $modelGUID   = $model_data[ 'modelGUID' ];
          $editGUID    = $model_data[ 'editGUID' ];
 
+         // Extract from model dataDescrip
+         // REGEX EXTRACT HMETRIC DW KS EXCKURT if present and build a json to store in model table
+         $json_keys = array( 'HMETRIC', 'DW', 'KS', 'EXCKURT' );
+         foreach ( $json_keys as $key )
+         {
+            if ( array_key_exists($key, $stats) && isset($stats[ $key ]) )
+            {
+                continue;
+            }
+            elseif ( preg_match( "/$key=([0-9]+.?[0-9eE\-+]*)/", $model_data[ 'dataDescrip' ], $matches ) )
+            {
+                $stats[$key] = $matches[1];
+            }
+            else
+            {
+                $stats[$key] = null;
+            }
+         }
+         
          if ( $mc_iteration > 1 )
          {
 ##write_logld( "$me:   MODELUpd: mc_iteration=$mc_iteration" );
@@ -563,6 +592,7 @@ write_logld( "$me:   mrecs file editGUID=$editGUID" );
 write_logld( "$me:   MODELUpd: O:description=$description" );
          }
 
+         $enc_stats = mysqli_real_escape_string( $db_handle, json_encode( $stats ) );
          $query = "INSERT INTO ${us3_db}.model SET "       .
                   "modelGUID='$modelGUID',"      .
                   "editedDataID="                .
@@ -571,7 +601,8 @@ write_logld( "$me:   MODELUpd: O:description=$description" );
                   "MCIteration='$mc_iteration'," .
                   "meniscus='$meniscus'," .
                   "variance='$variance'," .
-                  "xml='" . mysqli_real_escape_string( $db_handle, $xml ) . "'";
+                  "xml='" . mysqli_real_escape_string( $db_handle, $xml ) . "'," .
+                  "stats='$enc_stats'";
 
          $result = mysqli_query( $db_handle, $query );
 


### PR DESCRIPTION
This pull request enhances the `gfac_cleanup` function in `jobmonitor/cleanup_gfac.php` to extract and store additional statistical metrics from model files and descriptions. The main changes involve parsing specific metrics using regular expressions, aggregating them into a JSON object, and saving this data in a new `stats` field in the database.

**Extraction and Storage of Additional Model Metrics:**

* Added logic to extract the metrics `HMETRIC`, `DW`, `KS`, and `EXCKURT` from each model file line using regular expressions, storing any found values in a `$stats` array.
* Supplemented metric extraction by also parsing the `dataDescrip` field from model data, ensuring all four metrics are present in `$stats` (setting to `null` if not found).

**Database Integration:**

* JSON-encoded the `$stats` array and escaped it for safe SQL insertion.
* Modified the database insert query to include the new `stats` column, storing the encoded metrics alongside each model record.