### PR TITLE
Fix race condition causing intermittent "Failed data fetch"

### DIFF
--- a/cleanup.php
+++ b/cleanup.php
@@ -1061,7 +1061,9 @@ write_log( "$me:  not-exist-stderr: num_try=$num_try" );
       {
          exec( $tarcmd, $output, $stat );
          if ( $stat != 0 )
+         {
             write_log( "$me: Bad exec:\n$tarcmd\n" . implode( "\n", $output ) );
+         }
       }
       $num_try++;
       $secwait *= 2;

--- a/cleanup.php
+++ b/cleanup.php
@@ -922,7 +922,9 @@ function get_local_files( $gfac_link, $cluster, $requestID, $id, $gfacID )
    // Get stdout, stderr, output/analysis-results.tar
    $output = array();
 
-   if ( $is_us3iab == 0 )
+   $used_scp = ( $is_us3iab == 0 );
+
+   if ( $used_scp )
    {
       // For "-local", recompute remote work directory
       $clushost = "$cluster.hs.umt.edu";
@@ -965,11 +967,18 @@ write_log( "$me:  -LOCAL: remoteDir=$remoteDir" );
       if ( ! is_dir( "$work/$gfacID" ) ) mkdir( "$work/$gfacID", 0770 );
       $pwd = chdir( "$work/$gfacID" );
 
-      $cmd = "scp $ruser@$clushost:$remoteDir/output/analysis-results.tar . 2>&1";
+      $tarcmd = "scp $ruser@$clushost:$remoteDir/output/analysis-results.tar . 2>&1";
 
-      exec( $cmd, $output, $stat );
+      exec( $tarcmd, $output, $stat );
       if ( $stat != 0 )
-         write_log( "$me: Bad exec:\n$cmd\n" . implode( "\n", $output ) );
+      {
+         write_log( "$me: Bad exec:\n$tarcmd\n" . implode( "\n", $output ) );
+         sleep( 10 );
+         write_log( "$me: RETRY" );
+         exec( $tarcmd, $output, $stat );
+         if ( $stat != 0 )
+            write_log( "$me: Bad exec:\n$tarcmd\n" . implode( "\n", $output ) );
+      }
 
       $cmd = "scp $ruser@$clushost:$remoteDir/stdout . 2>&1";
 
@@ -1038,6 +1047,27 @@ write_log( "$me:  not-exist-stderr: num_try=$num_try" );
 
    $fn1_tarfile = "analysis-results.tar";
    $fn2_tarfile = "output/" . $fn1_tarfile;
+
+   // The remote job may finish writing stdout/stderr before it finishes
+   // writing/closing analysis-results.tar, so the earlier scp of the tar
+   // can race ahead of the result being ready.  Retry with backoff before
+   // giving up, separately from the stderr wait above.
+   $secwait = 10;
+   $num_try = 0;
+   while ( ! file_exists( $fn1_tarfile )  &&  ! file_exists( $fn2_tarfile )  &&  $num_try < 3 )
+   {
+      sleep( $secwait );
+      if ( $used_scp )
+      {
+         exec( $tarcmd, $output, $stat );
+         if ( $stat != 0 )
+            write_log( "$me: Bad exec:\n$tarcmd\n" . implode( "\n", $output ) );
+      }
+      $num_try++;
+      $secwait *= 2;
+write_log( "$me:  not-exist-tarfile: num_try=$num_try" );
+   }
+
    if ( file_exists( $fn1_tarfile ) )
       $tarfile = file_get_contents( $fn1_tarfile );
    else if ( file_exists( $fn2_tarfile ) )

--- a/jobmonitor/cleanup.php
+++ b/jobmonitor/cleanup.php
@@ -1099,7 +1099,9 @@ write_logld( "$me:  not-exist-stderr: num_try=$num_try" );
       {
          exec( $tarcmd, $output, $stat );
          if ( $stat != 0 )
+         {
             write_logld( "$me: Bad exec:\n$tarcmd\n" . implode( "\n", $output ) );
+         }
       }
       $num_try++;
       $secwait *= 2;

--- a/jobmonitor/cleanup.php
+++ b/jobmonitor/cleanup.php
@@ -952,7 +952,9 @@ function get_local_files( $db_handle, $cluster, $requestID, $id, $gfacID )
    ## Get stdout, stderr, output/analysis-results.tar
    $output = array();
 
-   if ( $is_us3iab == 0 || $cluster == "us3iab-node1" )
+   $used_scp = ( $is_us3iab == 0 || $cluster == "us3iab-node1" );
+
+   if ( $used_scp )
    {
        write_logld( "$me get_local_files(): scp to get files" );
 
@@ -1003,11 +1005,18 @@ write_logld( "$me:  -LOCAL: remoteDir=$remoteDir" );
       if ( ! is_dir( "$work/$gfacID" ) ) mkdir( "$work/$gfacID", 0770 );
       $pwd = chdir( "$work/$gfacID" );
 
-      $cmd = "scp $ruser@$clushost:$remoteDir/output/analysis-results.tar . 2>&1";
+      $tarcmd = "scp $ruser@$clushost:$remoteDir/output/analysis-results.tar . 2>&1";
 
-      exec( $cmd, $output, $stat );
+      exec( $tarcmd, $output, $stat );
       if ( $stat != 0 )
-         write_logld( "$me: Bad exec:\n$cmd\n" . implode( "\n", $output ) );
+      {
+         write_logld( "$me: Bad exec:\n$tarcmd\n" . implode( "\n", $output ) );
+         sleep( 10 );
+         write_logld( "$me: RETRY" );
+         exec( $tarcmd, $output, $stat );
+         if ( $stat != 0 )
+            write_logld( "$me: Bad exec:\n$tarcmd\n" . implode( "\n", $output ) );
+      }
 
       $cmd = "scp $ruser@$clushost:$remoteDir/stdout . 2>&1";
 
@@ -1076,6 +1085,27 @@ write_logld( "$me:  not-exist-stderr: num_try=$num_try" );
 
    $fn1_tarfile = "analysis-results.tar";
    $fn2_tarfile = "output/" . $fn1_tarfile;
+
+   ## The remote job may finish writing stdout/stderr before it finishes
+   ## writing/closing analysis-results.tar, so the earlier scp of the tar
+   ## can race ahead of the result being ready.  Retry with backoff before
+   ## giving up, separately from the stderr wait above.
+   $secwait = 10;
+   $num_try = 0;
+   while ( ! file_exists( $fn1_tarfile )  &&  ! file_exists( $fn2_tarfile )  &&  $num_try < 3 )
+   {
+      sleep( $secwait );
+      if ( $used_scp )
+      {
+         exec( $tarcmd, $output, $stat );
+         if ( $stat != 0 )
+            write_logld( "$me: Bad exec:\n$tarcmd\n" . implode( "\n", $output ) );
+      }
+      $num_try++;
+      $secwait *= 2;
+write_logld( "$me:  not-exist-tarfile: num_try=$num_try" );
+   }
+
    if ( file_exists( $fn1_tarfile ) )
       $tarfile = file_get_contents( $fn1_tarfile );
    else if ( file_exists( $fn2_tarfile ) )


### PR DESCRIPTION
## Summary
- The `analysis-results.tar` scp in `get_local_files()` had no retry, while the sibling stdout/stderr scp's already retried once.
- The only wait/backoff loop polled for the local `stderr` file's arrival, not the tar — so if the remote job finished writing stderr before closing the tar, the tar fetch silently failed and was never retried, leaving `gfac.analysis.tarfile` empty and the job marked "Failed data fetch" even though it actually succeeded.
- Adds a retry to the tar scp (matching stdout/stderr) and a dedicated backoff loop that re-checks for and re-fetches the tar before giving up. Applied identically to `cleanup.php` and `jobmonitor/cleanup.php`.

Fixes ehb54/ultrascan-tickets#914

## Test plan
- [ ] Deploy to a test LIMS install and re-run a job under cluster load to confirm "Failed data fetch" no longer occurs for successful jobs
- [ ] Confirm `php -l` passes on both modified files in the deployed environment
