### PR TITLE
Detect job submission failures in submitone.php's CLI error checks

### DIFF
--- a/submitone.php
+++ b/submitone.php
@@ -67,6 +67,26 @@ function check_cli_errors() {
     }
 }
 
+## The included web pages (e.g. 2DSA_2.php) don't push job submission
+## failures into $cli_errors themselves - they only echo an ERROR:
+## line into the dumped output. Scan the dump for that and fold any
+## such lines into $cli_errors so check_cli_errors() catches them too.
+function check_cli_errors_in_dump() {
+    global $dumpfile;
+    global $cli_errors;
+
+    if ( ! file_exists( $dumpfile ) ) {
+        return;
+    }
+
+    $dump = file_get_contents( $dumpfile );
+    if ( preg_match_all( '/^.*ERROR:.*$/m', $dump, $matches ) ) {
+        foreach ( $matches[ 0 ] as $line ) {
+            $cli_errors[] = $line;
+        }
+    }
+}
+
 function fail_job() {
     global $lims_db;
     global $cli_errors;
@@ -562,6 +582,7 @@ if ( $stage == "PCSA" ) {
     ob_start( "dump_it" );
     include( $php_pcsa_1 );
     while (ob_get_level()) ob_end_flush();
+    check_cli_errors_in_dump();
     check_cli_errors();
 
 } else {
@@ -686,6 +707,7 @@ if ( $stage == "PCSA" ) {
     ob_start( "dump_it" );
     include( $php_2dsa_1 );
     while (ob_get_level()) ob_end_flush();
+    check_cli_errors_in_dump();
     check_cli_errors();
 }
 


### PR DESCRIPTION
## Summary
- `submitone.php` drives CLI-based job submission by `include()`-ing the same web pages used by the browser UI. After each stage it calls `check_cli_errors()`, which fails the autoflow request if `$cli_errors` is non-empty.
- `$cli_errors[]` was only ever populated by early guard checks inside the included pages (insufficient user level, MOTD block) — never by an actual job submission failure (e.g. the `sbatch` failure case fixed in ehb54/us3lims_common#21). So `submitone.php` would complete its run and report success even when the job was never actually submitted.
- Adds `check_cli_errors_in_dump()`, which scans the already-buffered dump output for any `ERROR:` line and folds it into `$cli_errors`, called right before `check_cli_errors()` after both the PCSA and 2DSA job-type includes.
- Doesn't change GMP/autoflow's own failure detection, which already correctly polls `autoflowAnalysis.status` directly (`SUBMIT_TIMEOUT`, from ehb54/us3lims_common#21) — this only gives `submitone.php` itself an immediate signal for the run it just performed.

Fixes ehb54/ultrascan-tickets#917

## Test plan
- [x] Run a normal successful CLI submission and confirm it still completes and updates status normally
- [x] Simulate an `sbatch` failure (per ehb54/us3lims_common#21's test plan) via a CLI-driven submission and confirm `submitone.php` now calls `fail_job()` and the autoflow request status reflects the failure immediately, rather than appearing to succeed
