### PR TITLE
jobmonitor: finalize COMPLETE jobs robustly (issue #969)

### DIFF
--- a/jobmonitor/cleanup.php
+++ b/jobmonitor/cleanup.php
@@ -674,7 +674,7 @@ write_logld( "$me:     mrecs entry updated : mrecsID=$mrecsID" );
 
    mail_to_user( "success", "" );
 
-   return( 1 );
+   return 1;
 }
 
 function mail_to_user( $type, $msg )

--- a/jobmonitor/cleanup.php
+++ b/jobmonitor/cleanup.php
@@ -670,9 +670,11 @@ write_logld( "$me:     mrecs entry updated : mrecsID=$mrecsID" );
 ##   mysqli_close( $db_handle );
 
    ########/
-   ## Send email 
+   ## Send email
 
    mail_to_user( "success", "" );
+
+   return( 1 );
 }
 
 function mail_to_user( $type, $msg )

--- a/jobmonitor/cleanup_gfac.php
+++ b/jobmonitor/cleanup_gfac.php
@@ -255,7 +255,9 @@ write_logld( "$me:     NO get_local_files()" );
          $elapsed = time() - $seen;
          write_logld( "$me: complete-since: seen=$seen now=" . time() . " elapsed=$elapsed grace=$grace ceil=$ceil" );
          if ( $elapsed > $grace )
+         {
             $need_finish = false;
+         }
          if ( $elapsed > $ceil )
          {
             write_logld( "$me: complete ceiling ($ceil s) exceeded for $gfacID - forcing finalize" );
@@ -277,7 +279,9 @@ write_logld( "$me:     NO get_local_files()" );
 
    ## Finalizing this job: drop the complete-seen marker.
    if ( is_file( $seen_file ) )
+   {
       @unlink( $seen_file );
+   }
 
    $query = "DELETE FROM gfac.queue_messages " .
             "WHERE analysisID = $analysisID ";
@@ -719,7 +723,7 @@ write_logld( "$me:   MODELUpd: O:description=$description" );
    update_autoflow_status( $status, $queue_msg );
    mail_to_user( "success", "" );
 
-   return( 1 );
+   return 1;
 }
 
 function get_autoflow_type_id() {

--- a/jobmonitor/cleanup_gfac.php
+++ b/jobmonitor/cleanup_gfac.php
@@ -136,7 +136,7 @@ function gfac_cleanup( $us3_db, $reqID, $db_handle )
    {
       write_logld( "$me: Cleanup analysis query found 0 entries for $gfacID" );
       update_autoflow_status( 'FAILED', "Cleanup analysis query found 0 entries for $gfacID" );
-      return( 0 );
+      return( -1 );
    }
 ##else
 ##{
@@ -182,7 +182,7 @@ write_logld( "$me:     NO get_local_files()" );
    {
       write_logld( "$me: Cleanup analysis query found 0 entries for $gfacID" );
       update_autoflow_status( 'FAILED', "Cleanup analysis query found 0 entries for $gfacID" );
-      return( 0 );
+      return( -1 );
    }
 
    list( $analysisID, $stderr, $stdout, $tarfile ) = mysqli_fetch_array( $result );
@@ -218,29 +218,50 @@ write_logld( "$me:     NO get_local_files()" );
                   "Processed: $now\n\n" .
                   "Queue Messages\n\n" ;
 
+   global $lock_dir;
+   global $ll_base_dir;
+   global $global_complete_grace_seconds;
+   global $global_complete_max_seconds;
+
+   $seen_dir  = ( isset( $lock_dir ) && $lock_dir != "" ) ? $lock_dir : "$ll_base_dir/$db/$gfacID";
+   $seen_file = "$seen_dir/complete_seen";
+
    $need_finish = ( $status == 'COMPLETE' );
 
    if ( mysqli_num_rows( $result ) > 0 )
    {
-      $time_msg = time();
       while ( list( $message, $time ) = mysqli_fetch_array( $result ) )
       {
 ##write_logld( "$me: message=$message" );
          $message_log .= "$time $message\n";
          if ( preg_match( "/^Finished/i", $message ) )
             $need_finish = false;
-         $time_msg = strtotime( $time );
       }
 
       if ( $need_finish )
-      {  ## No 'Finished' yet:  forget if too much time has passed
-         $time_now = time();
-         $tdelta   = $time_now - $time_msg;
-write_logld( "$me: no-Finish time: tnow=$time_now, tmsg=$time_msg, tdelt=$tdelta" );
-         if ( $tdelta > 600 )
+      {  ## No UDP 'Finished' message yet.  UDP is unreliable, so finalize
+         ## anyway once enough time has passed since the job was first seen
+         ## COMPLETE.  Timing uses the jobmonitor's own clock (epoch seconds),
+         ## so it is immune to any timezone/clock skew between the LIMS host,
+         ## the cluster, and the DB (which broke the old strtotime() check).
+         $grace = isset( $global_complete_grace_seconds ) ? (int) $global_complete_grace_seconds : 600;
+         $ceil  = isset( $global_complete_max_seconds )   ? (int) $global_complete_max_seconds   : 21600;
+         $seen  = is_file( $seen_file ) ? (int) trim( @file_get_contents( $seen_file ) ) : 0;
+         if ( $seen <= 0 )
+         {
+            $seen = time();
+            @file_put_contents( $seen_file, $seen );
+         }
+         $elapsed = time() - $seen;
+         write_logld( "$me: complete-since: seen=$seen now=" . time() . " elapsed=$elapsed grace=$grace ceil=$ceil" );
+         if ( $elapsed > $grace )
             $need_finish = false;
+         if ( $elapsed > $ceil )
+         {
+            write_logld( "$me: complete ceiling ($ceil s) exceeded for $gfacID - forcing finalize" );
+            $need_finish = false;
+         }
       }
-##write_logld( "$me: no-Finish time: tnow=$time_now, tmsg=$time_msg, tdelt=$tdelta" );
    }
    else
    {
@@ -253,6 +274,10 @@ write_logld( "$me: no-Finish time: tnow=$time_now, tmsg=$time_msg, tdelt=$tdelta
       write_logld( "$me: Cleanup has not yet found 'Finished' for $gfacID" );
       return( 0 );
    }
+
+   ## Finalizing this job: drop the complete-seen marker.
+   if ( is_file( $seen_file ) )
+      @unlink( $seen_file );
 
    $query = "DELETE FROM gfac.queue_messages " .
             "WHERE analysisID = $analysisID ";
@@ -693,6 +718,8 @@ write_logld( "$me:   MODELUpd: O:description=$description" );
 
    update_autoflow_status( $status, $queue_msg );
    mail_to_user( "success", "" );
+
+   return( 1 );
 }
 
 function get_autoflow_type_id() {

--- a/jobmonitor/gridctl.php
+++ b/jobmonitor/gridctl.php
@@ -536,7 +536,7 @@ function cleanup() {
     if ( ! $result ) {
         write_logld( "Query failed $query - " .  mysqli_error( $db_handle ) );
         mail_to_admin( "fail", "Query failed $query\n" .  mysqli_error( $db_handle ) );
-        return( -1 );
+        return -1;
     }
 
     list( $count ) = mysqli_fetch_array( $result );
@@ -544,14 +544,14 @@ function cleanup() {
     ##if ($count==0)
     ##write_logld( "count = $count  gfacID = $gfacID" );
     if ( $count == 0 ) {
-        return( 1 );          ## gfacID no longer in gfac.analysis: nothing to do
+        return 1;          ## gfacID no longer in gfac.analysis: nothing to do
     }
 
     ## Now check the us3 instance
     $requestID = get_us3_data();
     ##write_logld( "requestID = $requestID  gfacID = $gfacID" );
     if ( $requestID == 0 ) {
-        return( -1 );
+        return -1;
     }
 
     ## Return the cleanup result to the caller:

--- a/jobmonitor/gridctl.php
+++ b/jobmonitor/gridctl.php
@@ -124,7 +124,14 @@ function check_job() {
         case "COMPLETED":
             case "COMPLETE":
             write_logld( "  COMPLETE gfacID=$gfacID" );
-            complete( $gfacID );
+            ## complete() returns 0 when cleanup could not yet finalize the job
+            ## (e.g. the cluster's UDP 'Finished' message has not arrived and the
+            ## grace period has not elapsed).  Keep monitoring and retry on the
+            ## next poll rather than exiting and orphaning the job.
+            if ( complete( $gfacID ) === 0 ) {
+                write_logld( "  COMPLETE not yet finalized gfacID=$gfacID - will retry" );
+                return false;
+            }
             return true;
             break;
 
@@ -505,7 +512,7 @@ function data_timeout( $updatetime ) {
 function complete( $gfacID ) {
     ## Just cleanup
     update_job_status( "COMPLETE", $gfacID );
-    cleanup();
+    return cleanup();
 }
 
 function failed() {
@@ -529,7 +536,7 @@ function cleanup() {
     if ( ! $result ) {
         write_logld( "Query failed $query - " .  mysqli_error( $db_handle ) );
         mail_to_admin( "fail", "Query failed $query\n" .  mysqli_error( $db_handle ) );
-        return;
+        return( -1 );
     }
 
     list( $count ) = mysqli_fetch_array( $result );
@@ -537,23 +544,26 @@ function cleanup() {
     ##if ($count==0)
     ##write_logld( "count = $count  gfacID = $gfacID" );
     if ( $count == 0 ) {
-        return;
+        return( 1 );          ## gfacID no longer in gfac.analysis: nothing to do
     }
 
     ## Now check the us3 instance
     $requestID = get_us3_data();
     ##write_logld( "requestID = $requestID  gfacID = $gfacID" );
     if ( $requestID == 0 ) {
-        return;
+        return( -1 );
     }
 
+    ## Return the cleanup result to the caller:
+    ##   -1 = terminal (user/admin already notified), 0 = not yet finalizable
+    ##   (retry on the next poll), 1 = finalized successfully.
     if ( preg_match( "/US3-A/i", $gfacID ) ) {
         write_logld( "calling aria_cleanup() reqID=$requestID" );
-        aira_cleanup( $us3_db, $requestID, $db_handle );
+        return aira_cleanup( $us3_db, $requestID, $db_handle );
     } else {
         ## Non-airavata job:  clean up in a non-aira way
         write_logld( "calling gfac_cleanup() reqID=$requestID" );
-        gfac_cleanup( $us3_db, $requestID, $db_handle );
+        return gfac_cleanup( $us3_db, $requestID, $db_handle );
     }
 }
 


### PR DESCRIPTION
Fixes ehb54/ultrascan-tickets#969

## Problem
Five zentriforce jobs completed on the cluster on 2026-07-15 but were not finalized/emailed until a manual `uslims_jobs.php --running --restart` ~14.5h later. Two interacting bugs:

1. **`jobmonitor` exits without finalizing.** `check_job()`'s COMPLETE case called `complete()` and then unconditionally `return true`, so the monitor `exit(0)`d even when `gfac_cleanup()` returned `0` ("Finished not recorded yet — retry later"). The retry signal was discarded, orphaning the job (analysis row left, no live monitor).
2. **Clock/timezone skew defeated the finalize fallback.** `gfac_cleanup()` finalized without a "Finished" message once the message stream was quiet >10 min, via `time() - strtotime($queue_messages.time) > 600`. A ~7h skew made that delta `-25200`, never `> 600`, so the fallback never fired. The "Finished" message arrives over an unreliable UDP queue, so the system must not depend on it.

## Changes (all in the live `jobmonitor/` copies)
- **`gridctl.php`** — `check_job()` COMPLETE case retries (returns `false`, keeps polling) when `complete()` returns `0`; stops on `1` (finalized) / `-1` (terminal). `cleanup()`/`complete()` propagate the `gfac_cleanup()`/`aira_cleanup()` result. Contract: `-1` terminal, `0` retry, `1` finalized.
- **`cleanup_gfac.php`** — finalize grace is now timed on the jobmonitor's **own epoch clock** via a per-job marker file `$lock_dir/complete_seen` (survives restarts, immune to tz/clock skew), with a hard ceiling to bound retries. Grace/ceiling from `$global_complete_grace_seconds` / `$global_complete_max_seconds` (default 600 / 21600). The two terminal "0 entries → FAILED" returns changed `0`→`-1`; explicit `return(1)` added on success.
- **`cleanup.php`** — `aira_cleanup()` returns `1` on success for contract consistency (it has no grace-wait logic, so no timing change).

Config tunables added in a companion PR to **us3lims_common** (`global_config.php.template`); code defaults apply when unset.

## Notes
- Scope: `main` only, `jobmonitor/` copies (the path production runs). The older root `gridctl_pro/dev` copies are untouched.
- PHP-lint clean.
- Validation still needs a dev LIMS / mock (skewed-tz finalize, retry-then-finalize, restart-resume, ceiling).